### PR TITLE
YSMOD-227 Endepunkt for å hente et vedlegg

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/skadeforklaring/api/v1/VedleggController.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/skadeforklaring/api/v1/VedleggController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.yrkesskade.skadeforklaring.api.handlers.ErrorResponse
+import no.nav.yrkesskade.skadeforklaring.model.Vedlegg
 import no.nav.yrkesskade.skadeforklaring.security.AutentisertBruker
 import no.nav.yrkesskade.skadeforklaring.security.ISSUER
 import no.nav.yrkesskade.skadeforklaring.security.LEVEL
@@ -49,6 +50,30 @@ class VedleggController(val autentisertBruker: AutentisertBruker, val storageSer
             autentisertBruker.fodselsnummer
         )
         return ResponseEntity.status(HttpStatus.CREATED).header(HttpHeaders.LOCATION, url).build()
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Hent vedlegg")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200", description = "Vedlegg hentet",
+                content = [Content()]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "Internal Server Error",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ErrorResponse::class)
+                )]
+            ),
+        ]
+    )
+    fun hentVedlegg(@PathVariable("id") id: String): ResponseEntity<Vedlegg?> {
+        val blob = storageService.hent(id, autentisertBruker.fodselsnummer) ?: return ResponseEntity.notFound().build()
+        val vedlegg = Vedlegg(blob.bytes ?: byteArrayOf(), blob.navn ?: "")
+        return ResponseEntity.ok(vedlegg)
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/kotlin/no/nav/yrkesskade/skadeforklaring/services/StorageService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/skadeforklaring/services/StorageService.kt
@@ -32,6 +32,17 @@ class StorageService(@Value("\${storage.type:MEMORY}") val storageType: String, 
         )
     }
 
+    fun hent(id: String, brukerIdentifikator: String): Blob? =
+        storage.getBlob(
+            Blob(
+                id = id,
+                bruker = brukerIdentifikator,
+                null,
+                null,
+                null
+            )
+        )
+
     fun slett(id: String, brukerIdentifikator: String): Boolean =
         storage.deleteBlob(
             Blob(

--- a/src/test/kotlin/no/nav/yrkesskade/skadeforklaring/api/v1/VedleggControllerIT.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/skadeforklaring/api/v1/VedleggControllerIT.kt
@@ -1,10 +1,10 @@
 package no.nav.yrkesskade.skadeforklaring.api.v1
 
 import no.nav.yrkesskade.skadeforklaring.test.AbstractTest
+import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
@@ -48,6 +48,50 @@ class VedleggControllerIT : AbstractTest() {
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isCreated)
             .andExpect(MockMvcResultMatchers.redirectedUrl("/blob/test"))
+    }
+
+    @Test
+    fun `hent vedlegg som finnes - autentisert`() {
+        val jwt = mvc.perform(MockMvcRequestBuilders.get("/local/jwt")).andReturn().response.contentAsString
+
+        val mockMultipartFile = MockMultipartFile(
+            "vedlegg", "test.pdf",
+            "application/pdf", "test data".toByteArray()
+        )
+
+        val bytesTilHenting = "til_henting".toByteArray(Charsets.UTF_8)
+        val part = MockPart("id", bytesTilHenting)
+
+        // Data for eksterne tjenester kommer fra localhost MockServer
+        mvc.perform(
+            MockMvcRequestBuilders.multipart(VEDLEGG_PATH)
+                .file(mockMultipartFile)
+                .part(part)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .characterEncoding(Charsets.UTF_8)
+
+        )
+
+        mvc.perform(
+            MockMvcRequestBuilders.get("$VEDLEGG_PATH/{id}", "til_henting")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(containsString("test.pdf")))
+    }
+
+    @Test
+    fun `hent vedlegg som ikke finnes - autentisert`() {
+        val jwt = mvc.perform(MockMvcRequestBuilders.get("/local/jwt")).andReturn().response.contentAsString
+
+        mvc.perform(
+            MockMvcRequestBuilders.get("$VEDLEGG_PATH/{id}", "finnes_ikke")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isNotFound)
     }
 
     @Test


### PR DESCRIPTION
Nytt endepunkt tenkt til å kalles fra mottak ved journalføring av vedleggene til skadeforklaring. Endepunktet bruker autentisertBruker.fodselsnummer i kallet til lagringstjenesten. Jeg er usikker på om det vil fungere når det kalles fra en annen app og ikke med innlogget bruker??